### PR TITLE
Decode close message

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -164,7 +164,14 @@ module Discord
 
     private def on_close(message : String)
       # TODO: make more sophisticated
-      @logger.warn "[#{@client_name}] Closed with: " + message
+      code = nil
+      reason = nil
+      unless message.empty?
+        io = IO::Memory.new(message)
+        code = io.read_bytes(UInt16, IO::ByteFormat::NetworkEndian)
+        reason = io.gets_to_end
+      end
+      @logger.warn "[#{@client_name}] Closed with: #{code} #{reason}"
 
       @send_heartbeats = false
       @session.try &.suspend


### PR DESCRIPTION
Adds decoding of the binary string from the close frame per [RFC 6455 §5.5.1](https://tools.ietf.org/html/rfc6455#section-5.5.1)

Before:
```
W, [2018-06-30 09:48:29 -04:00 #23180]  WARN -- discordcr: [Client] Closed with: �
```
After:
```
W, [2018-06-30 09:48:07 -04:00 #23094]  WARN -- discordcr: [Client] Closed with: 1002
```