### PR TITLE
Parse session_start_limit in REST#get_gateway_bot

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -114,6 +114,21 @@ describe Discord do
     end
   end
 
+  describe Discord::TimeSpanMillisecondsConverter do
+    it ".from_json" do
+      parser = JSON::PullParser.new("300")
+      span = Discord::TimeSpanMillisecondsConverter.from_json(parser)
+      span.should eq 300.milliseconds
+    end
+
+    it ".to_json" do
+      json = JSON.build do |builder|
+        Discord::TimeSpanMillisecondsConverter.to_json(300.milliseconds, builder)
+      end
+      json.should eq "300"
+    end
+  end
+
   it ".shard_id" do
     part = 3_u64 << 22
     shard = Discord.shard_id(part, 2)

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -37,4 +37,14 @@ module Discord
       end
     end
   end
+
+  module TimeSpanMillisecondsConverter
+    def self.from_json(parser : JSON::PullParser)
+      parser.read_int.milliseconds
+    end
+
+    def self.to_json(value : Time::Span, builder : JSON::Builder)
+      builder.scalar(value.milliseconds)
+    end
+  end
 end

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -13,7 +13,17 @@ module Discord
     struct GatewayBotResponse
       JSON.mapping(
         url: String,
-        shards: Int32
+        shards: Int32,
+        session_start_limit: SessionStartLimit
+      )
+    end
+
+    # Session start limit details included in the Get Gateway Bot REST API call.
+    struct SessionStartLimit
+      JSON.mapping(
+        total: Int32,
+        remaining: Int32,
+        reset_after: {type: Time::Span, converter: TimeSpanMillisecondsConverter}
       )
     end
 


### PR DESCRIPTION
Parses the `session_start_limit` object in `GatewayBotResponse`

[Discord documentation](https://discordapp.com/developers/docs/topics/gateway#get-gateway-bot)

```cr
require "./src/discordcr"
pp Discord::Client.new(ENV["TOKEN"]).get_gateway_bot
```
```
I, [2019-01-11 06:16:33 +00:00 #4081]  INFO -- discordcr: [HTTP OUT] GET /gateway/bot (0 bytes)
I, [2019-01-11 06:16:33 +00:00 #4081]  INFO -- discordcr: [HTTP IN] 200 OK (131)
Discord::REST::GatewayBotResponse(
 @session_start_limit=
  Discord::REST::SessionStartLimit(
   @remaining=999,
   @reset_after=10:57:14.507000000,
   @total=1000),
 @shards=1,
 @url="wss://gateway.discord.gg")
```