### PR TITLE
Fix Mention::Role#size parsing

### DIFF
--- a/spec/mention_spec.cr
+++ b/spec/mention_spec.cr
@@ -19,7 +19,7 @@ describe Discord::Mention do
 
     it_parses_message(
       "<@&123>",
-      into: [Discord::Mention::Role.new(123_u64, 0, 6)])
+      into: [Discord::Mention::Role.new(123_u64, 0, 7)])
 
     it_parses_message(
       "<#123>",

--- a/src/discordcr/mention.cr
+++ b/src/discordcr/mention.cr
@@ -54,7 +54,7 @@ module Discord::Mention
 
               if next_char.ascii_number?
                 snowflake = scan_snowflake(pos)
-                yield Role.new(snowflake, start, pos - start) if has_next? && current_char == '>'
+                yield Role.new(snowflake, start, pos - start + 1) if has_next? && current_char == '>'
               end
             when .ascii_number?, '!'
               next_char                        # Skip mention indicator


### PR DESCRIPTION
Fixes a small off-by-one error in `Role#size` when parsing role mentions