### PR TITLE
Add spoiler argument to Client#upload_file

### DIFF
--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -404,7 +404,7 @@ module Discord
         end
       end
 
-      if spoiler
+      if spoiler && !filename.starts_with?("SPOILER_")
         filename = "SPOILER_" + filename
       end
 

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -393,7 +393,7 @@ module Discord
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#create-message)
     # (same as `#create_message` -- this method implements form data bodies
     # while `#create_message` implements JSON bodies)
-    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil)
+    def upload_file(channel_id : UInt64 | Snowflake, content : String?, file : IO, filename : String? = nil, spoiler : Bool = false)
       io = IO::Memory.new
 
       unless filename
@@ -402,6 +402,10 @@ module Discord
         else
           filename = ""
         end
+      end
+
+      if spoiler
+        filename = "SPOILER_" + filename
       end
 
       builder = HTTP::FormData::Builder.new(io)


### PR DESCRIPTION
This adds a `spoiler` argument to [`Client#upload_file`](https://meew0.github.io/discordcr/doc/master/Discord/REST.html#upload_file%28channel_id%3AUInt64%7CSnowflake%2Ccontent%3AString%3F%2Cfile%3AIO%2Cfilename%3AString%3F%3Dnil%29-instance-method) which marks the image as a spoiler and is just the same as: 
![image](https://user-images.githubusercontent.com/35064754/52167270-ebc89400-2718-11e9-997d-606ef73535a2.png)
