### PR TITLE
Remove Client#accept_invite and use bulk-delete endpoint instead of bulk_delete

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -766,7 +766,7 @@ module Discord
     event message_delete, Gateway::MessageDeletePayload
 
     # Called when multiple messages are deleted at once, due to a bot using the
-    # bulk_delete endpoint.
+    # bulk-delete endpoint.
     #
     # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#message-delete-bulk)
     event message_delete_bulk, Gateway::MessageDeleteBulkPayload

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -463,7 +463,7 @@ module Discord
         :channels_cid_messages_bulk_delete,
         channel_id,
         "POST",
-        "/channels/#{channel_id}/messages/bulk_delete",
+        "/channels/#{channel_id}/messages/bulk-delete",
         HTTP::Headers{"Content-Type" => "application/json"},
         {messages: message_ids}.to_json
       )
@@ -1459,27 +1459,6 @@ module Discord
         :invites_code,
         nil,
         "DELETE",
-        "/invites/#{code}",
-        HTTP::Headers.new,
-        nil
-      )
-
-      Invite.from_json(response.body)
-    end
-
-    # Makes a user accept an invite. Will not work for bots.
-    # For example, this can be used with a `Client` instantiated with an OAuth2
-    # `Bearer` token that has been granted the `guilds.join` scope.
-    # ```
-    # client = Discord::Client.new token: "Bearer XYZ"
-    # client.accept_invite("ABCdef")
-    # ```
-    # [API docs for this method](https://discordapp.com/developers/docs/resources/invite#accept-invite)
-    def accept_invite(code : String)
-      response = request(
-        :invites_code,
-        nil,
-        "POST",
         "/invites/#{code}",
         HTTP::Headers.new,
         nil


### PR DESCRIPTION
The current endpoint that is used for bulk-deleting is deprecated:
https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages-deprecated
Now the new one is used.
This also removes [`Client#accept_invite`](https://meew0.github.io/discordcr/doc/master/Discord/REST.html#accept_invite%28code%3AString%29-instance-method) which has been deprecated as well and is already discontinued (no longer works):
https://discordapp.com/developers/docs/change-log#deprecation-accept-invite-endpoint