### PR TITLE
Rename Client#get_users_connections to Client#get_user_connections

### DIFF
--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1496,8 +1496,8 @@ module Discord
 
     # Gets a list of connections the user has set up (Twitch, YouTube, etc.)
     #
-    # [API docs for this method](https://discordapp.com/developers/docs/resources/user#get-users-connections)
-    def get_users_connections
+    # [API docs for this method](https://discordapp.com/developers/docs/resources/user#get-user-connections)
+    def get_user_connections
       response = request(
         :users_me_connections,
         nil,


### PR DESCRIPTION
In the API it's called Get User Connections: https://discordapp.com/developers/docs/resources/user#get-user-connections, not Get Users Connections. The link is wrong too. I think the endpoint name has been renamed in the past but it wasn't updated here.