### PR TITLE
Channel.icon was expecting the wrong type

### DIFF
--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -77,7 +77,7 @@ module Discord
       user_limit: UInt32?,
       recipients: Array(User)?,
       nsfw: Bool?,
-      icon: Bool?,
+      icon: String?,
       owner_id: Snowflake?,
       application_id: Snowflake?,
       position: Int32?,


### PR DESCRIPTION
I was getting a JSON parse error when loading private channels. Not sure what happened here but discordcr expected the icon parameter to be Bool? but according to the [Discord reference](https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure) this field is of type String?