### PR TITLE
Add REST#modify_guild_role_positions method

### DIFF
--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -61,5 +61,17 @@ module Discord
         end
       end
     end
+
+    struct ModifyRolePositionPayload
+      JSON.mapping(
+        id: Snowflake,
+        position: Int32
+      )
+
+      def initialize(id : UInt64 | Snowflake, @position : Int32)
+        id = Snowflake.new(id) unless id.is_a?(Snowflake)
+        @id = id
+      end
+    end
   end
 end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1151,6 +1151,24 @@ module Discord
       Role.from_json(response.body)
     end
 
+    # Changes the position of roles. Requires the "Manage Roles" permission
+    # and you cannot raise roles above the bot's highest role.
+    #
+    # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions)
+    def modify_guild_role_positions(guild_id : UInt64 | Snowflake,
+                                    positions : Array(ModifyRolePositionPayload))
+      response = request(
+        :guilds_gid_roles,
+        guild_id,
+        "PATCH",
+        "/guilds/#{guild_id}/roles",
+        HTTP::Headers{"Content-Type" => "application/json"},
+        positions.to_json
+      )
+
+      Array(Role).from_json(response.body)
+    end
+
     # Deletes a role. Requires the "Manage Roles" permission as well as the role
     # to be lower than the bot's highest role.
     #


### PR DESCRIPTION
Allows users to modify the order of roles: https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions