### PR TITLE
Updates for Crystal 0.28.0

### DIFF
--- a/examples/multicommand.cr
+++ b/examples/multicommand.cr
@@ -28,7 +28,7 @@ client.on_message_create do |payload|
     suffix = command.split(' ')[1..-1].join(" ")
     client.create_message(payload.channel_id, suffix)
   when PREFIX + "date"
-    client.create_message(payload.channel_id, Time.now.to_s("%D"))
+    client.create_message(payload.channel_id, Time.utc.to_s("%D"))
   end
 end
 

--- a/examples/ping_with_response_time.cr
+++ b/examples/ping_with_response_time.cr
@@ -10,7 +10,7 @@ client.on_message_create do |payload|
   if payload.content.starts_with? "!ping"
     # We first create a new Message, and then we check how long it took to send the message by comparing it to the current time
     m = client.create_message(payload.channel_id, "Pong!")
-    time = Time.utc_now - payload.timestamp
+    time = Time.utc - payload.timestamp
     client.edit_message(m.channel_id, m.id, "Pong! Time taken: #{time.total_milliseconds} ms.")
   end
 end

--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -95,7 +95,7 @@ describe Discord do
   describe Discord::WebSocket::Packet do
     it "inspects" do
       packet = Discord::WebSocket::Packet.new(0_i64, 1_i64, IO::Memory.new("foo"), "test")
-      packet.inspect.should eq %(Discord::WebSocket::Packet(@opcode=0_i64 @sequence=1_i64 @data="foo" @event_type="test"))
+      packet.inspect.should eq %(Discord::WebSocket::Packet(@opcode=0 @sequence=1 @data="foo" @event_type="test"))
     end
 
     it "serializes" do

--- a/spec/snowflake_spec.cr
+++ b/spec/snowflake_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe Discord::Snowflake do
   describe Discord::DISCORD_EPOCH do
     it "is 2015-01-01" do
-      expected = Time.new(2015, 1, 1, location: Time::Location::UTC)
+      expected = Time.utc(2015, 1, 1)
       Discord::DISCORD_EPOCH.should eq expected.to_unix_ms
     end
   end
@@ -35,7 +35,7 @@ describe Discord::Snowflake do
 
   describe "#creation_time" do
     it "returns the time the snowflake was created" do
-      time = Time.new(2018, 4, 18)
+      time = Time.utc(2018, 4, 18)
       snowflake = Discord::Snowflake.new(time)
       snowflake.creation_time.should eq time
     end


### PR DESCRIPTION
Pretty sure our only use of deprecated API was `Time.utc_now` & `Time.new` with `location`.