### PR TITLE
wrong doc for get_guild_roles

### DIFF
--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1082,7 +1082,7 @@ module Discord
       )
     end
 
-    # Get a list of roles on the guild. Requires the "Manage Roles" permission.
+    # Get a list of roles on the guild.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#get-guild-roles)
     def get_guild_roles(guild_id : UInt64 | Snowflake)


### PR DESCRIPTION
I believe that get_guild_roles doesn't require the Manage Roles perm.

https://discordapp.com/developers/docs/resources/guild#get-guild-roles