### PR TITLE
Add GamePlaying::Type

### DIFF
--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -245,12 +245,21 @@ module Discord
   end
 
   struct GamePlaying
-    def initialize(@name = nil, @type = nil, @url = nil)
+    def initialize(@name = nil, @type : Type? = nil, @url = nil)
+    end
+
+    # All the activities for the status of the current user.
+    enum Type
+      Playing = 0
+      # This activity only has effect when a Twitch URL is given.
+      Streaming = 1
+      Listening = 2
+      Watching = 3
     end
 
     JSON.mapping(
       name: String?,
-      type: Int64? | String?,
+      type: Type?,
       url: String?
     )
   end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -251,7 +251,7 @@ module Discord
     # All the activities for the status of the current user.
     enum Type
       Playing = 0
-      # This activity only has effect when a Twitch URL is given.
+      # This activity only has effect when `url` is a Twitch URL.
       Streaming = 1
       Listening = 2
       Watching = 3

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -255,6 +255,7 @@ module Discord
       Streaming = 1
       Listening = 2
       Watching = 3
+      Custom = 4
     end
 
     JSON.mapping(


### PR DESCRIPTION
This adds the `Type` enum to `GamePlaying` and makes it the required type for the `type` argument. It also removes the `String` type from `type` since that's a legacy type for that field.