### PR TITLE
Add MESSAGE_REACTION_REMOVE_EMOJI event and endpoint

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -833,7 +833,7 @@ module Discord
     # Called when all reactions are removed at once from a message.
     event message_reaction_remove_all, Gateway::MessageReactionRemoveAllPayload
 
-    # Called when all reactions of a given emoji are removed at once from a message.
+    # Called when all reactions of a single emoji are removed at once from a message.
     event message_reaction_remove_emoji, Gateway::MessageReactionRemoveEmojiPayload
 
     # Called when a message is updated. Most commonly this is done for edited

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -609,6 +609,9 @@ module Discord
       when "MESSAGE_REACTION_REMOVE_ALL"
         payload = Gateway::MessageReactionRemoveAllPayload.from_json(data)
         call_event message_reaction_remove_all, payload
+      when "MESSAGE_REACTION_REMOVE_EMOJI"
+        payload = Gateway::MessageReactionRemoveEmojiPayload.from_json(data)
+        call_event message_reaction_remove_emoji, payload
       when "MESSAGE_UPDATE"
         payload = Gateway::MessageUpdatePayload.from_json(data)
         call_event message_update, payload
@@ -829,6 +832,9 @@ module Discord
 
     # Called when all reactions are removed at once from a message.
     event message_reaction_remove_all, Gateway::MessageReactionRemoveAllPayload
+
+    # Called when all reactions of a given emoji are removed at once from a message.
+    event message_reaction_remove_emoji, Gateway::MessageReactionRemoveEmojiPayload
 
     # Called when a message is updated. Most commonly this is done for edited
     # messages, but the event is also sent when embed information for an

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -320,6 +320,15 @@ module Discord
       )
     end
 
+    struct MessageReactionRemoveEmojiPayload
+      JSON.mapping(
+        channel_id: Snowflake,
+        guild_id: Snowflake,
+        message_id: Snowflake,
+        emoji: ReactionEmoji
+      )
+    end
+
     struct MessageUpdatePayload
       JSON.mapping(
         type: UInt8?,

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -408,6 +408,21 @@ module Discord
       )
     end
 
+    # Removes all reactions for a given emoji from a message. Requires the "Manage Messages"
+    # permission.
+    #
+    # [API Docs for this method]()
+    def delete_reaction(channel_id : UInt64 | Snowflake, message_id : UInt64 | Snowflake, emoji : String)
+      request(
+        :channels_cid_messages_mid_reactions_emoji,
+        channel_id,
+        "DELETE",
+        "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}",
+        HTTP::Headers.new,
+        nil
+      )
+    end
+
     # Uploads a file to a channel. Requires the "Send Messages" and "Attach
     # Files" permissions.
     #


### PR DESCRIPTION
Adds the new MESSAGE_REACTION_REMOVE_EMOJI gateway event as well as the new endpoint that comes with it.