### PR TITLE
Add INVITE_CREATE and INVITE_DELETE

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -590,6 +590,14 @@ module Discord
         @cache.try &.remove_guild_role(payload.guild_id, payload.role_id)
 
         call_event guild_role_delete, payload
+      when "INVITE_CREATE"
+        payload = Gateway::InviteCreatePayload.from_json(data)
+
+        call_event invite_create, payload
+      when "INVITE_DELETE"
+        payload = Gateway::InviteDeletePayload.from_json(data)
+
+        call_event invite_delete, payload
       when "MESSAGE_CREATE"
         payload = Message.from_json(data)
 
@@ -819,6 +827,16 @@ module Discord
     #
     # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#guild-role-delete)
     event guild_role_delete, Gateway::GuildRoleDeletePayload
+
+    # Called when an invite is created on a guild.
+    #
+    # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-create)
+    event invite_create, Gateway::InviteCreatePayload
+    
+    # Called when an invite is deleted.
+    #
+    # [API docs for this event](https://discordapp.com/developers/docs/topics/gateway#invite-delete)
+    event invite_delete, Gateway::InviteDeletePayload
 
     # Called when a message is sent to a channel the bot has access to. This
     # may be any sort of text channel, no matter private or guild.

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -302,6 +302,27 @@ module Discord
       )
     end
 
+    struct InviteCreatePayload
+      JSON.mapping(
+        channel_id: Snowflake,
+        code: String,
+        created_at: {type: Time?, converter: MaybeTimestampConverter},
+        guild_id: Snowflake?,
+        inviter: User?,
+        max_age: Int32,
+        max_uses: Int32,
+        temporary: Bool
+      )
+    end
+
+    struct InviteDeletePayload
+      JSON.mapping(
+        channel_id: Snowflake,
+        guild_id: Snowflake?,
+        code: String
+      )
+    end
+
     struct MessageReactionPayload
       JSON.mapping(
         user_id: Snowflake,


### PR DESCRIPTION
Adds the invite_create and invite_delete events

(Didn't include `uses` cause it's always 0 (https://discordapp.com/developers/docs/topics/gateway#invite-create-invite-create-event-fields))